### PR TITLE
Customfields with enumaration values can be retrieved now

### DIFF
--- a/src/TeamleaderDotNet/Common/Throttler.cs
+++ b/src/TeamleaderDotNet/Common/Throttler.cs
@@ -23,7 +23,7 @@ namespace TeamleaderDotNet.Common
                     var result = task.Invoke();
                     return result;
                 }
-                Task.Delay(TimeSpan.FromSeconds(1000));
+                Task.Delay(TimeSpan.FromSeconds(5));
             }
             s_timeOfFirstCall = DateTime.Now;
             s_currentNumberOfCalls = 1;

--- a/src/TeamleaderDotNet/CustomFields/CustomFieldInfo.cs
+++ b/src/TeamleaderDotNet/CustomFields/CustomFieldInfo.cs
@@ -1,0 +1,20 @@
+﻿using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using TeamleaderDotNet.Crm;
+
+namespace TeamleaderDotNet.CustomFields
+{
+    public class CustomFieldInfo : Entity
+    {
+        [JsonProperty(PropertyName = "id")]
+        public int Id { get; set; }
+        [JsonProperty(PropertyName = "name")]
+        public string Name { get; set; }
+        [JsonProperty(PropertyName = "for")]
+        public string ForObjectType { get; set; }
+        [JsonProperty(PropertyName = "type")]
+        public string Type { get; set; }
+        [JsonProperty(PropertyName = "options")]
+        public JObject Options { get; set; }
+    }
+}

--- a/src/TeamleaderDotNet/Deals/Deal.cs
+++ b/src/TeamleaderDotNet/Deals/Deal.cs
@@ -21,7 +21,7 @@ namespace TeamleaderDotNet.Deals
 
         [TeamleaderDataType(Name = "for_id")]
         [JsonProperty(PropertyName = "for_id")]
-        public string ForId { get; set; }
+        public int ForId { get; set; }
 
         [TeamleaderDataType(Name = "offerte_nr")]
         [JsonProperty(PropertyName = "offerte_nr")]

--- a/src/TeamleaderDotNet/TeamleaderCustomFieldsApi.cs
+++ b/src/TeamleaderDotNet/TeamleaderCustomFieldsApi.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.Caching;
 using System.Threading.Tasks;
 using TeamleaderDotNet.Common;
 using TeamleaderDotNet.Crm;
@@ -26,10 +27,28 @@ namespace TeamleaderDotNet
             return await DoCall<List<CustomField>>("getCustomFields.php", new List<KeyValuePair<string, string>>
             {
                 new KeyValuePair<string, string>("for", objectType)
-            });  
+            });
         }
-
-
+        /// <summary>
+        /// Getting the extra info of a custom field from cache or via api call to Teamleader
+        /// </summary>
+        /// <param name="customFieldId">The CustomField ID</param>
+        /// <returns></returns>
+        public async Task<CustomFieldInfo> GetCustomFieldInfo(int customFieldId)
+        {
+            var cacheKey = "customfield_" + customFieldId;
+            var cache = MemoryCache.Default;
+            var customFieldInfo = cache[cacheKey] as CustomFieldInfo;
+            if (customFieldInfo == null)
+            {
+                customFieldInfo = await DoCall<CustomFieldInfo>("getCustomFieldInfo.php", new List<KeyValuePair<string, string>>
+                {
+                    new KeyValuePair<string, string>("custom_field_id", customFieldId.ToString())
+                });
+                cache.Add(cacheKey, customFieldInfo, new CacheItemPolicy(){SlidingExpiration = TimeSpan.FromHours(1)});
+            }
+            return customFieldInfo;
+        }
 
     }
 }

--- a/src/TeamleaderDotNet/TeamleaderDotNet.csproj
+++ b/src/TeamleaderDotNet/TeamleaderDotNet.csproj
@@ -41,6 +41,7 @@
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Net.Http" />
+    <Reference Include="System.Runtime.Caching" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
@@ -56,6 +57,7 @@
     <Compile Include="Crm\PaymentTerm.cs" />
     <Compile Include="Crm\TeamleaderDataTypeAttribute.cs" />
     <Compile Include="Common\JsonConvertors\UnixDateConverter.cs" />
+    <Compile Include="CustomFields\CustomFieldInfo.cs" />
     <Compile Include="Deals\Deal.cs" />
     <Compile Include="General\BookkeepingAccount.cs" />
     <Compile Include="General\Department.cs" />


### PR DESCRIPTION
If a customfield contained enumeration values you only got back the id of the enumeration. An extra call is needed to get the correct value.
The customfield extension is for another pull request. still testing it.

I also fixed an issue with the throttler.